### PR TITLE
Changed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /*.iml
 /.idea
 .lein-*
+/resources/public/js/*
 
 *~
 \#*\#


### PR DESCRIPTION
resources/public/js/配下はcljsから生成されるようなので、git管理から除外して良いと思います。

以下を参考にしました。
https://github.com/magomimmo/modern-cljs/blob/master/.gitignore
(pom.xmlなども除外して良さそうですが、普通に起動する分には生成されないので追加していません)
