### PR TITLE
exclude servlet-api from ring, ring-defaults.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,9 +20,9 @@
                  [datomic-schema "1.3.0"]
                  [liberator "0.13"]
 
-                 [ring/ring-defaults "0.1.4"]
-                 [ring "1.3.2"]]
-  
+                 [ring/ring-defaults "0.1.4" :exclusions [[javax.servlet/servlet-api]]]
+                 [ring "1.3.2" :exclusions [[org.eclipse.jetty.orbit/javax.servlet]]]]
+
     :plugins [[lein-ring "0.9.3"]
               [lein-cljsbuild "1.0.5"]
               [lein-environ "1.0.0"]]


### PR DESCRIPTION
cloneし、lein cljsbuild once, lein run したところ以下のエラーが発生しました。
https://gist.github.com/tenten0213/4228c19bf75ffc64acb2

UndertowはServlet 3.1に依存していますが、ring, ring-defaultsは Servlet 2.5 に依存しているのでエラーが出たようです。
- [back-channelingのdeps-tree](https://gist.github.com/kazuhira-r/afb67993fe3ae2897512)

ringとring-defaultsからservletを除外することで上記のエラーが発生しなくなりました。
