### PR TITLE
Enable to build valid release artifact.

### DIFF
--- a/bin/back_channeling
+++ b/bin/back_channeling
@@ -2,5 +2,5 @@
 
 version=$(cat `dirname $0`/../VERSION)
 
-exec java -cp dist/back-channeling-${version}.jar:"lib/*" clojure.main -m back-channeling.core
+exec java -cp dist/back-channeling-${version}.jar:"lib/*" clojure.main -m back-channeling.main
 

--- a/bin/back_channeling.bat
+++ b/bin/back_channeling.bat
@@ -4,7 +4,7 @@ pushd %0\..\..
 
 set /p VERSION=<VERSION
 
-java -cp dist\back-channeling-%VERSION%.jar;"lib\*" clojure.main -m back-channeling.core
+java -cp dist\back-channeling-%VERSION%.jar;"lib\*" clojure.main -m back-channeling.main
 
 pause
 

--- a/bin/transactor
+++ b/bin/transactor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-datomic_version=0.9.5206
+datomic_version=0.9.5385
 datomic_dir=datomic-free-${datomic_version}
 
 function get_datomic () {

--- a/src/clj/back_channeling/main.clj
+++ b/src/clj/back_channeling/main.clj
@@ -1,4 +1,5 @@
 (ns back-channeling.main
+  (:gen-class)
   (:require [com.stuartsierra.component :as component]
             [duct.middleware.errors :refer [wrap-hide-errors]]
             [duct.util.runtime :refer [add-shutdown-hook]]


### PR DESCRIPTION
I added  :gen-class attribute to main.clj.
Whithout this I got following message and could not run uberjar.
> Warning: The Main-Class specified does not exist within the jar. It may not be executable as expected. A gen-clased.