### PR TITLE
Move on-click to form dom and submit from event object

### DIFF
--- a/src/cljs/back_channeling/components/root.cljs
+++ b/src/cljs/back_channeling/components/root.cljs
@@ -116,8 +116,9 @@
            [:form.menu.transition {:class (if open-profile? "visible" "hidden")
                                    :action (str (om/get-shared owner :prefix) "/logout")
                                    :method :post
-                                   :name "logout"}
-            [:a.item {:on-click (fn [_] (.. js/document -logout submit))} "Logout"]]]]]
+                                   :name "logout"
+                                   :on-click (fn [e] (.. e -currentTarget submit))}
+            [:a.item "Logout"]]]]]
         (case (:page app)
           :boards (om/build boards-view (:boards app))
           :board (om/build board-view app


### PR DESCRIPTION
```
Uncaught TypeError: Cannot read property 'submit' of undefined
    at React.createElement.React.createElement.onClick (back-channeling.min.js:1544)
    at Object.r (back-channeling.min.js:38)
    at a (back-channeling.min.js:36)
    at Object.s [as executeDispatchesInOrder] (back-channeling.min.js:36)
    at f (back-channeling.min.js:36)
    at m (back-channeling.min.js:36)
    at Array.forEach (<anonymous>)
    at r (back-channeling.min.js:39)
    at Object.processEventQueue (back-channeling.min.js:36)
    at r (back-channeling.min.js:38)
```
The error raised in production with chrome.
But, I can't reproduce the error in local.

Because  it say 'submit' of undefined,  replace `(.. js/document -logout submit)` of `(.. e -currentTarget submit)`.
