### PR TITLE
WebSocket message-based auth + board-scoped notifications

### DIFF
--- a/src/clj/back_channeling/bot/core.clj
+++ b/src/clj/back_channeling/bot/core.clj
@@ -107,8 +107,7 @@
 (defn- connect-ws!
   [config ai-provider ^ScheduledExecutorService executor]
   (let [access-token (get-token)
-        ws-url (str (server-url->ws-url (:server-url config))
-                    "/ws?token=" access-token)]
+        ws-url (str (server-url->ws-url (:server-url config)) "/ws")]
     (close-old-ws!)
     (try
       (let [ws (bot-ws/connect! ws-url
@@ -129,7 +128,9 @@
                                 (long 5) TimeUnit/SECONDS))
                   :on-error (fn [error]
                               (.println System/err (str "WebSocket error: " (.getMessage error))))})]
-        (swap! state assoc :ws-connection ws))
+        (swap! state assoc :ws-connection ws)
+        ;; Authenticate via message instead of URL query parameter
+        (.sendText ws (pr-str [:auth {:token access-token}]) true))
       (catch Exception e
         (.println System/err (str "WebSocket connection failed: " (.getMessage e)))
         (.schedule executor

--- a/src/clj/back_channeling/resource/comment.clj
+++ b/src/clj/back_channeling/resource/comment.clj
@@ -3,7 +3,7 @@
             [datomic.api :as d]
             (back-channeling [util :refer [parse-request]]
                              [mention :as mention])
-            [back-channeling.websocket.socketapp :refer [broadcast-message multicast-message]]
+            [back-channeling.websocket.socketapp :refer [board-multicast-message multicast-message]]
             (back-channeling.boundary [comments :as comments]
                                       [read-comments :as read-comments]
                                       [threads :as threads]
@@ -15,14 +15,15 @@
 
 (defn- broadcast-thread-update
   [socketapp datomic board-name thread-id & {:keys [comment-no user resnum]}]
-  (broadcast-message
+  (board-multicast-message
    socketapp
    [:update-thread (cond-> {:db/id thread-id
                              :thread/last-updated (Date.)
                              :thread/resnum (or resnum (comments/count datomic thread-id))
                              :board/name board-name}
                      comment-no (assoc :comments/no comment-no)
-                     user       (assoc :comment/posted-by user))]))
+                     user       (assoc :comment/posted-by user))]
+   board-name))
 
 (defn comments-resource [{:keys [datomic socketapp]} board-name thread-id from to]
   (liberator/resource

--- a/src/clj/back_channeling/resource/thread.clj
+++ b/src/clj/back_channeling/resource/thread.clj
@@ -3,7 +3,7 @@
             [datomic.api :as d]
 
             (back-channeling [util :refer [parse-request]])
-            [back-channeling.websocket.socketapp :refer [broadcast-message]]
+            [back-channeling.websocket.socketapp :refer [board-multicast-message]]
             (back-channeling.boundary [threads :as threads]
                                       [users :as users])
             (back-channeling.resource [base :refer [base-resource has-permission? thread-allowed?
@@ -27,7 +27,7 @@
                   [tempids temp-thread-id] (threads/save datomic board-name th user)
                   thread-id (d/resolve-tempid (d/db (:connection datomic)) tempids temp-thread-id)]
               (threads/add-watcher datomic thread-id identity)
-              (broadcast-message socketapp [:update-board {:board/name board-name}])
+              (board-multicast-message socketapp [:update-board {:board/name board-name}] board-name)
               {:db/id thread-id}))
 
    :handle-ok (fn [{{{:keys [q]} :params} :request :as ctx}]
@@ -53,10 +53,10 @@
              (when (has-permission? ctx #{:read-any-thread})
                (when open-thread
                  (threads/open-thread datomic thread-id)
-                 (broadcast-message socketapp [:update-board {:board/name board-name}]))
+                 (board-multicast-message socketapp [:update-board {:board/name board-name}] board-name))
                (when close-thread
                  (threads/close-thread datomic thread-id)
-                 (broadcast-message socketapp [:update-board {:board/name board-name}])))))
+                 (board-multicast-message socketapp [:update-board {:board/name board-name}] board-name)))))
 
    :handle-created (fn [_]
                      {:status "ok"})

--- a/src/clj/back_channeling/websocket/socketapp.clj
+++ b/src/clj/back_channeling/websocket/socketapp.clj
@@ -9,37 +9,49 @@
 (defprotocol ISendMessage
   (broadcast-message [this message])
   (multicast-message [this message users])
+  (board-multicast-message [this message board-name])
   (on-connect [this exchange channel])
   (on-message [this channel message])
   (on-close   [this channel close-reason]))
 
+;; Channel data structure:
+;; {path {channel {:user {:user/name "..." :user/email "..."}
+;;                 :board "board-name-or-nil"}}}
+;; :user is nil until :auth command is received.
+
 (defn find-users [{:keys [channels path]}]
   (->> (get @channels path)
        vals
-       (keep identity)
+       (keep :user)
        (apply hash-set)))
 
 (defn find-user-by-channel [{:keys [channels path]} ch]
-  (get-in @channels [path ch]))
+  (get-in @channels [path ch :user]))
 
 (defn find-user-by-name [{:keys [channels path]} user-name]
   (->> (get @channels path)
        vals
-       (keep identity)
+       (keep :user)
        (filter #(= (:user/name %) user-name))
        first))
 
-(defn- token-from-request [exchange]
-  (-> (.getRequestParameters exchange)
-      (.get "token")
-      first))
-
 (defmulti handle-command (fn [socketapp msg ch] (first msg)))
+
+(defmethod handle-command :auth [{:keys [channels path cache] :as socketapp} [_ {:keys [token]}] ch]
+  (when-let [user (some-> (tokens/auth-by cache token)
+                          (select-keys [:user/name :user/email]))]
+    (swap! channels assoc-in [path ch :user] user)
+    (broadcast-message socketapp [:join user])))
+
+(defmethod handle-command :subscribe-board [{:keys [channels path]} [_ {:keys [board/name]}] ch]
+  (when (and name (get-in @channels [path ch :user]))
+    (swap! channels assoc-in [path ch :board] name)))
 
 (defmethod handle-command :leave [socketapp [_ message] ch]
   (broadcast-message socketapp
                      [:leave {:user/name (:user/name message)
                               :user/email (:user/email message)}]))
+
 (defmethod handle-command :call [socketapp [_ message] ch]
   (multicast-message socketapp
                      [:call message]
@@ -47,32 +59,43 @@
 
 (defrecord Socketapp [channels path cache logger])
 
+(defn- make-ws-callback [logger user]
+  (proxy [WebSocketCallback] []
+    (complete [channel context])
+    (onError [channel context throwable]
+      (log logger :warn ::ws-send-error {:user user :error throwable}))))
+
 (extend-type Socketapp
   ISendMessage
   (broadcast-message [{:keys [channels path logger]} message]
-    (doseq [[channel user] (get @channels path)]
-      (WebSockets/sendText (pr-str message) channel
-                           (proxy [WebSocketCallback] []
-                             (complete [channel context])
-                             (onError [channel context throwable]
-                               (log logger :warn ::ws-send-error {:user user :error throwable}))))))
-  (multicast-message [{:keys [channels path logger]} message users]
-    (doseq [[channel user] (get @channels path)]
-      (when (users user)
+    (doseq [[channel {:keys [user]}] (get @channels path)]
+      (when user
         (WebSockets/sendText (pr-str message) channel
-                             (proxy [WebSocketCallback] []
-                               (complete [channel context])
-                               (onError [channel context throwable]
-                                 (log logger :warn ::ws-send-error {:user user :error throwable})))))))
+                             (make-ws-callback logger user)))))
 
-  (on-connect [{:keys [channels path cache] :as socketapp} exchange channel]
-    (if-let [user (some-> (tokens/auth-by cache (token-from-request exchange))
-                          (select-keys [:user/name :user/email]))]
-      (do
-        (swap! channels assoc-in [path channel] user)
-        (broadcast-message socketapp [:join user]))))
-  (on-message [socketapp ch message]
-    (handle-command socketapp (edn/read-string message) ch))
+  (multicast-message [{:keys [channels path logger]} message users]
+    (doseq [[channel {:keys [user]}] (get @channels path)]
+      (when (and user (users user))
+        (WebSockets/sendText (pr-str message) channel
+                             (make-ws-callback logger user)))))
+
+  (board-multicast-message [{:keys [channels path logger]} message board-name]
+    (doseq [[channel {:keys [user board]}] (get @channels path)]
+      (when (and user (= board board-name))
+        (WebSockets/sendText (pr-str message) channel
+                             (make-ws-callback logger user)))))
+
+  (on-connect [{:keys [channels path] :as socketapp} exchange channel]
+    ;; Store channel as unauthenticated. Client must send :auth message.
+    (swap! channels assoc-in [path channel] {:user nil :board nil}))
+
+  (on-message [{:keys [channels path] :as socketapp} ch message]
+    (let [parsed (edn/read-string message)
+          cmd (first parsed)
+          authenticated? (get-in @channels [path ch :user])]
+      ;; Only allow :auth command from unauthenticated channels
+      (when (or (= cmd :auth) authenticated?)
+        (handle-command socketapp parsed ch))))
 
   (on-close [{:keys [channels path] :as socketapp} ch close-reason]
     (let [user (find-user-by-channel socketapp ch)]

--- a/src/clj/back_channeling/websocket/socketapp.clj
+++ b/src/clj/back_channeling/websocket/socketapp.clj
@@ -3,7 +3,8 @@
             [duct.logger :refer [log]]
             [clojure.edn :as edn]
             (back-channeling.boundary [tokens :as tokens]))
-  (:import [io.undertow.websockets.core WebSockets WebSocketCallback]))
+  (:import [io.undertow.websockets.core WebSockets WebSocketCallback]
+           [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
 
 (defprotocol ISendMessage
@@ -37,6 +38,9 @@
 
 (defmulti handle-command (fn [socketapp msg ch] (first msg)))
 
+(defmethod handle-command :default [{:keys [logger]} [cmd] ch]
+  (log logger :warn ::unknown-command {:command cmd}))
+
 (defmethod handle-command :auth [{:keys [channels path cache] :as socketapp} [_ {:keys [token]}] ch]
   (when-let [user (some-> (tokens/auth-by cache token)
                           (select-keys [:user/name :user/email]))]
@@ -59,7 +63,7 @@
                      [:call message]
                      (:to message)))
 
-(defrecord Socketapp [channels path cache logger])
+(defrecord Socketapp [channels path cache logger scheduler])
 
 (defn- make-ws-callback [logger user]
   (proxy [WebSocketCallback] []
@@ -87,27 +91,33 @@
         (WebSockets/sendText (pr-str message) channel
                              (make-ws-callback logger user)))))
 
-  (on-connect [{:keys [channels path logger] :as socketapp} exchange channel]
+  (on-connect [{:keys [channels path logger ^ScheduledExecutorService scheduler] :as socketapp} exchange channel]
     ;; Store channel as unauthenticated. Client must send :auth message.
     (swap! channels assoc-in [path channel] {:user nil :board nil})
     ;; Close channel if not authenticated within 10 seconds
-    (future
-      (Thread/sleep 10000)
-      (when (and (get-in @channels [path channel])
-                 (nil? (get-in @channels [path channel :user])))
-        (log logger :info ::auth-timeout {:channel channel})
-        (try
-          (.sendClose channel 1008 "Authentication timeout")
-          (catch Exception _)))))
+    (.schedule scheduler
+      ^Runnable (fn []
+                  (when (and (get-in @channels [path channel])
+                             (nil? (get-in @channels [path channel :user])))
+                    (log logger :info ::auth-timeout {:channel channel})
+                    (try
+                      (.sendClose channel 1008 "Authentication timeout")
+                      (catch Exception _))))
+      (long 10) TimeUnit/SECONDS))
 
-  (on-message [{:keys [channels path] :as socketapp} ch message]
-    (let [parsed (edn/read-string message)
-          cmd (first parsed)
-          authenticated? (get-in @channels [path ch :user])]
-      ;; :auth only from unauthenticated; :leave only from on-close (internal)
-      (when (and (not= cmd :leave)
-                 (or (= cmd :auth) authenticated?))
-        (handle-command socketapp parsed ch))))
+  (on-message [{:keys [channels path logger] :as socketapp} ch message]
+    (try
+      (let [parsed (edn/read-string message)
+            cmd (first parsed)
+            authenticated? (get-in @channels [path ch :user])]
+        ;; :leave only from on-close (internal), :auth only when unauthenticated
+        (when (and (not= cmd :leave)
+                   (if (= cmd :auth)
+                     (not authenticated?)
+                     authenticated?))
+          (handle-command socketapp parsed ch)))
+      (catch Exception e
+        (log logger :warn ::ws-message-parse-error {:error (.getMessage e)}))))
 
   (on-close [{:keys [channels path] :as socketapp} ch close-reason]
     (let [user (find-user-by-channel socketapp ch)]
@@ -119,4 +129,9 @@
   (map->Socketapp {:logger logger
                    :channels (atom {})
                    :path path
-                   :cache cache}))
+                   :cache cache
+                   :scheduler (Executors/newSingleThreadScheduledExecutor)}))
+
+(defmethod ig/halt-key! :back-channeling.websocket/socketapp [_ {:keys [^ScheduledExecutorService scheduler]}]
+  (when scheduler
+    (.shutdown scheduler)))

--- a/src/clj/back_channeling/websocket/socketapp.clj
+++ b/src/clj/back_channeling/websocket/socketapp.clj
@@ -85,9 +85,18 @@
         (WebSockets/sendText (pr-str message) channel
                              (make-ws-callback logger user)))))
 
-  (on-connect [{:keys [channels path] :as socketapp} exchange channel]
+  (on-connect [{:keys [channels path logger] :as socketapp} exchange channel]
     ;; Store channel as unauthenticated. Client must send :auth message.
-    (swap! channels assoc-in [path channel] {:user nil :board nil}))
+    (swap! channels assoc-in [path channel] {:user nil :board nil})
+    ;; Close channel if not authenticated within 10 seconds
+    (future
+      (Thread/sleep 10000)
+      (when (and (get-in @channels [path channel])
+                 (nil? (get-in @channels [path channel :user])))
+        (log logger :info ::auth-timeout {:channel channel})
+        (try
+          (.sendClose channel 1008 "Authentication timeout")
+          (catch Exception _)))))
 
   (on-message [{:keys [channels path] :as socketapp} ch message]
     (let [parsed (edn/read-string message)

--- a/src/clj/back_channeling/websocket/socketapp.clj
+++ b/src/clj/back_channeling/websocket/socketapp.clj
@@ -43,14 +43,16 @@
     (swap! channels assoc-in [path ch :user] user)
     (broadcast-message socketapp [:join user])))
 
-(defmethod handle-command :subscribe-board [{:keys [channels path]} [_ {:keys [board/name]}] ch]
-  (when (and name (get-in @channels [path ch :user]))
-    (swap! channels assoc-in [path ch :board] name)))
+(defmethod handle-command :subscribe-board [{:keys [channels path]} [_ {board-name :board/name}] ch]
+  (when (and board-name (get-in @channels [path ch :user]))
+    (swap! channels assoc-in [path ch :board] board-name)))
 
+;; :leave is only dispatched internally from on-close — derive user from
+;; the channel data, never trust client-supplied fields.
 (defmethod handle-command :leave [socketapp [_ message] ch]
-  (broadcast-message socketapp
-                     [:leave {:user/name (:user/name message)
-                              :user/email (:user/email message)}]))
+  (when message
+    (broadcast-message socketapp
+                       [:leave (select-keys message [:user/name :user/email])])))
 
 (defmethod handle-command :call [socketapp [_ message] ch]
   (multicast-message socketapp
@@ -102,8 +104,9 @@
     (let [parsed (edn/read-string message)
           cmd (first parsed)
           authenticated? (get-in @channels [path ch :user])]
-      ;; Only allow :auth command from unauthenticated channels
-      (when (or (= cmd :auth) authenticated?)
+      ;; :auth only from unauthenticated; :leave only from on-close (internal)
+      (when (and (not= cmd :leave)
+                 (or (= cmd :auth) authenticated?))
         (handle-command socketapp parsed ch))))
 
   (on-close [{:keys [channels path] :as socketapp} ch close-reason]

--- a/src/cljs/back_channeling/events.cljs
+++ b/src/cljs/back_channeling/events.cljs
@@ -364,8 +364,11 @@
 
 (rf/reg-event-fx
  ::subscribe-board
- (fn [_ [_ board-name]]
-   {:ws-send {:command :subscribe-board :message {:board/name board-name}}}))
+ (fn [{:keys [db]} [_ board-name]]
+   ;; Only send if socket is connected. On reconnect, ::socket-opened
+   ;; will re-subscribe to the current board.
+   (when (= (:socket db) :connect)
+     {:ws-send {:command :subscribe-board :message {:board/name board-name}}})))
 
 (rf/reg-event-db
  ::socket-closed

--- a/src/cljs/back_channeling/events.cljs
+++ b/src/cljs/back_channeling/events.cljs
@@ -120,7 +120,8 @@
               (assoc db :board {} :threads {} :thread-order []))
             (assoc :page {:type :board :board/name name :loading? true})
             (dissoc :search-highlight))
-    :dispatch [::fetch-board name]}))
+    :dispatch-n [[::fetch-board name]
+                 [::subscribe-board name]]}))
 
 (rf/reg-event-fx
  ::fetch-board
@@ -323,10 +324,11 @@
  ::open-socket
  (fn [{:keys [db]} [_ token]]
    (let [prefix (:prefix db)]
-     {:ws-open {:url (str (if (= "https:" (.-protocol js/location)) "wss://" "ws://")
+     {:db (assoc db :ws-token token)
+      :ws-open {:url (str (if (= "https:" (.-protocol js/location)) "wss://" "ws://")
                           (.-host js/location)
                           prefix
-                          "/ws?token=" token)
+                          "/ws")
                 :on-open (fn []
                            (rf/dispatch [::socket-opened]))
                 :on-close (fn [_]
@@ -338,14 +340,32 @@
  ::socket-opened
  (fn [{:keys [db]} _]
    (let [was-disconnected? (= (:socket db) :disconnect)
-         thread-id (get-in db [:page :thread/id])]
-     (cond-> {:db (assoc db :socket :connect)}
-       (and was-disconnected? thread-id)
-       (assoc :dispatch [::fetch-comments
-                         {:thread {:db/id thread-id
-                                   :board/name (get-in db [:page :board/name])}
-                          :from (-> (get-in db [:threads thread-id :thread/comments]) count inc)
-                          :callback-event ::add-comments}])))))
+         thread-id (get-in db [:page :thread/id])
+         board-name (get-in db [:page :board/name])
+         dispatches (cond-> []
+                      ;; Always send auth on connect
+                      true (conj [::send-auth])
+                      ;; Subscribe to current board if any
+                      board-name (conj [::subscribe-board board-name])
+                      ;; Fetch missed comments on reconnect
+                      (and was-disconnected? thread-id)
+                      (conj [::fetch-comments
+                             {:thread {:db/id thread-id :board/name board-name}
+                              :from (-> (get-in db [:threads thread-id :thread/comments]) count inc)
+                              :callback-event ::add-comments}]))]
+     {:db (assoc db :socket :connect)
+      :dispatch-n dispatches})))
+
+(rf/reg-event-fx
+ ::send-auth
+ (fn [{:keys [db]} _]
+   (when-let [token (:ws-token db)]
+     {:ws-send {:command :auth :message {:token token}}})))
+
+(rf/reg-event-fx
+ ::subscribe-board
+ (fn [_ [_ board-name]]
+   {:ws-send {:command :subscribe-board :message {:board/name board-name}}}))
 
 (rf/reg-event-db
  ::socket-closed

--- a/src/cljs/back_channeling/events.cljs
+++ b/src/cljs/back_channeling/events.cljs
@@ -165,7 +165,8 @@
                                               :callback-event ::comments-fetched-for-thread}]
                            [::scroll-to-comment no]]}
        need-board-refresh?
-       (update :dispatch-n conj [::fetch-board name])))))
+       (update :dispatch-n into [[::fetch-board name]
+                                  [::subscribe-board name]])))))
 
 (rf/reg-event-fx
  ::fetch-comments

--- a/test/clj/back_channeling/test_helper.clj
+++ b/test/clj/back_channeling/test_helper.clj
@@ -19,6 +19,8 @@
     (swap! messages conj {:type :broadcast :message message}))
   (multicast-message [_ message users]
     (swap! messages conj {:type :multicast :message message :users users}))
+  (board-multicast-message [_ message board-name]
+    (swap! messages conj {:type :board-multicast :message message :board board-name}))
   (on-connect [_ exchange channel] nil)
   (on-message [_ ch message] nil)
   (on-close [_ ch close-reason] nil))

--- a/test/clj/back_channeling/websocket/socketapp_test.clj
+++ b/test/clj/back_channeling/websocket/socketapp_test.clj
@@ -1,0 +1,90 @@
+(ns back-channeling.websocket.socketapp-test
+  (:require [clojure.test :refer :all]
+            [duct.logger]
+            [back-channeling.websocket.socketapp :as sut]
+            [back-channeling.websocket.socketapp :refer [on-message on-connect
+                                                          board-multicast-message
+                                                          find-user-by-channel]])
+  (:import [java.util.concurrent Executors]))
+
+(def noop-logger
+  (reify duct.logger/Logger
+    (-log [_ level ns-str file line id event data] nil)))
+
+(defn- make-test-socketapp []
+  (sut/map->Socketapp
+   {:logger noop-logger
+    :channels (atom {})
+    :path "/ws"
+    :cache nil
+    :scheduler (Executors/newSingleThreadScheduledExecutor)}))
+
+(defn- inject-authenticated-channel
+  "Directly inject an authenticated channel into the socketapp for testing."
+  [socketapp ch user board]
+  (swap! (:channels socketapp) assoc-in ["/ws" ch] {:user user :board board}))
+
+(deftest on-message-rejects-commands-before-auth
+  (let [app (make-test-socketapp)
+        ch :fake-channel]
+    ;; Register unauthenticated channel
+    (swap! (:channels app) assoc-in ["/ws" ch] {:user nil :board nil})
+
+    ;; Send a non-auth command — should be ignored
+    (on-message app ch (pr-str [:call {:message "hi"}]))
+
+    ;; Channel should still be unauthenticated
+    (is (nil? (find-user-by-channel app ch)))))
+
+(deftest on-message-blocks-client-leave
+  (let [app (make-test-socketapp)
+        ch :fake-channel
+        user {:user/name "alice" :user/email "alice@test.com"}]
+    (inject-authenticated-channel app ch user nil)
+
+    ;; Client sends :leave — should be blocked
+    (on-message app ch (pr-str [:leave {:user/name "bob" :user/email "bob@test.com"}]))
+
+    ;; Alice should still be connected
+    (is (= user (find-user-by-channel app ch)))))
+
+(deftest on-message-rejects-auth-when-already-authenticated
+  (let [app (make-test-socketapp)
+        ch :fake-channel
+        user {:user/name "alice" :user/email "alice@test.com"}]
+    (inject-authenticated-channel app ch user nil)
+
+    ;; Send :auth again — should be ignored (already authenticated)
+    (on-message app ch (pr-str [:auth {:token "some-token"}]))
+
+    ;; User should remain alice (not changed)
+    (is (= user (find-user-by-channel app ch)))))
+
+(deftest on-message-handles-malformed-edn
+  (let [app (make-test-socketapp)
+        ch :fake-channel
+        user {:user/name "alice" :user/email "alice@test.com"}]
+    (inject-authenticated-channel app ch user nil)
+
+    ;; Send garbage — should not throw
+    (is (nil? (on-message app ch "{{{{not edn")))))
+
+(deftest board-multicast-sends-only-to-same-board
+  (let [app (make-test-socketapp)
+        ;; We can't easily test actual WebSocket sends, but we can verify
+        ;; the channel filtering logic by checking the channels atom structure
+        ch-a :channel-a
+        ch-b :channel-b
+        user-a {:user/name "alice" :user/email "alice@test.com"}
+        user-b {:user/name "bob" :user/email "bob@test.com"}]
+    (inject-authenticated-channel app ch-a user-a "board-1")
+    (inject-authenticated-channel app ch-b user-b "board-2")
+
+    ;; Verify channel state
+    (let [channels @(:channels app)
+          ws-channels (get channels "/ws")]
+      (is (= "board-1" (get-in ws-channels [ch-a :board])))
+      (is (= "board-2" (get-in ws-channels [ch-b :board])))
+      ;; board-multicast-message would only send to ch-a for "board-1"
+      ;; We verify the data structure is correct for the filtering logic
+      (is (= 2 (count ws-channels))))))


### PR DESCRIPTION
## Summary

Phase 2 of the security/performance improvement plan.

**S4 [High] — WebSocket token no longer in URL:**
- Token removed from `?token=` query parameter (was visible in logs, proxies, browser history)
- New `:auth` command sent as first WebSocket message after connection
- Server holds channel as unauthenticated until `:auth` is validated; rejects other commands

**P3 [High] — Board-scoped notifications:**
- Channel data extended with `:board` field
- New `:subscribe-board` command sent when user navigates to a board
- New `board-multicast-message` sends only to users viewing the same board
- `broadcast-thread-update` and `:update-board` now use board-multicast instead of broadcast-to-all
- Reduces unnecessary WebSocket traffic proportionally to number of boards

## Test plan

- [x] `lein test` passes (10 tests, 47 assertions, 0 failures)
- [ ] Manual: verify token not visible in WebSocket URL (browser dev tools Network tab)
- [ ] Manual: open 2 browser tabs on different boards, post comment → only same-board tab receives update
- [ ] Manual: bot connects and authenticates via `:auth` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)