### PR TITLE
Performance: N+1 batch, indexes, search limit, cache evict

### DIFF
--- a/resources/back_channeling/migration/v009_add_indexes.edn
+++ b/resources/back_channeling/migration/v009_add_indexes.edn
@@ -1,0 +1,4 @@
+[{:db/ident :thread/comments
+  :db/index true}
+ {:db/ident :read-comment/thread
+  :db/index true}]

--- a/src/clj/back_channeling/boundary/comments.clj
+++ b/src/clj/back_channeling/boundary/comments.clj
@@ -7,6 +7,7 @@
   (find-by-thread [datomic thread-id])
   (count [datomic thread-id])
   (count-writenum [datomic thread-id identity])
+  (count-writenums-batch [datomic thread-ids identity])
   (save [datomic comment])
   (hide [datomic thread-id comment-no])
   (add-reaction [datomic reaction thread-id comment-no user]))
@@ -38,6 +39,15 @@
                    [?comment :comment/posted-by ?user]
                    [?user :user/name ?user-name]]}
          (d/db connection) thread-id (:user/name identity)))
+
+  (count-writenums-batch [{:keys [connection]} thread-ids identity]
+    (let [results (d/q '{:find [?thread (count ?comment)]
+                         :in [$ [?thread ...] ?user-name]
+                         :where [[?thread :thread/comments ?comment]
+                                 [?comment :comment/posted-by ?user]
+                                 [?user :user/name ?user-name]]}
+                       (d/db connection) thread-ids (:user/name identity))]
+      (into {} results)))
 
   (save [{:keys [connection]} comment]
     (-> (d/transact connection comment)

--- a/src/clj/back_channeling/boundary/threads.clj
+++ b/src/clj/back_channeling/boundary/threads.clj
@@ -7,6 +7,7 @@
   (pull [datomic id])
   (find-threads [datomic board-name q])
   (find-thread  [datomic thread-id])
+  (find-thread-meta [datomic thread-id])
   (find-watchers [datomic thread-id])
 
   (add-watcher    [datomic thread-id identity])
@@ -57,6 +58,17 @@
          vec))
 
   (find-thread [{:keys [connection]} thread-id]
+    (-> (d/pull (d/db connection)
+                '[:*
+                  {:thread/comments
+                   [:*
+                    {:comment/format [:db/ident]}
+                    {:comment/posted-by [:user/name :user/email]}]}]
+                thread-id)
+        (update-in [:thread/comments]
+                   (partial map-indexed #(assoc %2 :comment/no (inc %1))))))
+
+  (find-thread-meta [{:keys [connection]} thread-id]
     (d/pull (d/db connection)
             '[:db/id :thread/title :thread/since :thread/last-updated :thread/public?
               {:thread/watchers [:user/name :user/email]}]

--- a/src/clj/back_channeling/boundary/threads.clj
+++ b/src/clj/back_channeling/boundary/threads.clj
@@ -53,18 +53,14 @@
          (map (fn [[k v]]
                 (apply max-key :score/value v)))
          (sort-by :score/value >)
+         (take 50)
          vec))
 
   (find-thread [{:keys [connection]} thread-id]
-    (-> (d/pull (d/db connection)
-                '[:*
-                  {:thread/comments
-                   [:*
-                    {:comment/format [:db/ident]}
-                    {:comment/posted-by [:user/name :user/email]}]}]
-                thread-id)
-        (update-in [:thread/comments]
-                   (partial map-indexed #(assoc %2 :comment/no (inc %1))))))
+    (d/pull (d/db connection)
+            '[:db/id :thread/title :thread/since :thread/last-updated :thread/public?
+              {:thread/watchers [:user/name :user/email]}]
+            thread-id))
 
   (find-watchers [{:keys [connection]} thread-id]
     (d/pull (d/db connection)

--- a/src/clj/back_channeling/database/cache.clj
+++ b/src/clj/back_channeling/database/cache.clj
@@ -6,10 +6,13 @@
 (defrecord Boundary [cache scheduler])
 
 (defn- evict-expired!
-  "Force eviction of expired entries by touching every key via has?."
+  "Force eviction of all expired entries in a single atomic swap."
   [cache-atom]
-  (doseq [k (keys @cache-atom)]
-    (swap! cache-atom #(if (cache/has? % k) % (cache/evict % k)))))
+  (swap! cache-atom
+    (fn [c]
+      (reduce (fn [acc k]
+                (if (cache/has? acc k) acc (cache/evict acc k)))
+              c (keys c)))))
 
 (defmethod ig/init-key :back-channeling.database/cache [_ {:keys [ttl] :or {ttl (* 30 60 1000)}}]
   (let [cache-atom (atom (cache/ttl-cache-factory {} :ttl ttl))

--- a/src/clj/back_channeling/database/cache.clj
+++ b/src/clj/back_channeling/database/cache.clj
@@ -1,8 +1,24 @@
 (ns back-channeling.database.cache
   (:require [integrant.core :as ig]
-            [clojure.core.cache :as cache]))
+            [clojure.core.cache :as cache])
+  (:import [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
-(defrecord Boundary [cache])
+(defrecord Boundary [cache scheduler])
 
-(defmethod ig/init-key :back-channeling.database/cache [_ {:keys [ttl]}]
-  (->Boundary (atom (cache/ttl-cache-factory {} :ttl (* 30 60 1000)))))
+(defn- evict-expired!
+  "Force eviction of expired entries by touching every key via has?."
+  [cache-atom]
+  (doseq [k (keys @cache-atom)]
+    (swap! cache-atom #(if (cache/has? % k) % (cache/evict % k)))))
+
+(defmethod ig/init-key :back-channeling.database/cache [_ {:keys [ttl] :or {ttl (* 30 60 1000)}}]
+  (let [cache-atom (atom (cache/ttl-cache-factory {} :ttl ttl))
+        scheduler (Executors/newSingleThreadScheduledExecutor)]
+    (.scheduleAtFixedRate scheduler
+      ^Runnable (fn [] (evict-expired! cache-atom))
+      (long 5) (long 5) TimeUnit/MINUTES)
+    (->Boundary cache-atom scheduler)))
+
+(defmethod ig/halt-key! :back-channeling.database/cache [_ {:keys [^ScheduledExecutorService scheduler]}]
+  (when scheduler
+    (.shutdown scheduler)))

--- a/src/clj/back_channeling/resource/board.clj
+++ b/src/clj/back_channeling/resource/board.clj
@@ -48,11 +48,14 @@
            (boards/save datomic (merge old board) (:db/id old)))
 
    :handle-ok (fn [{board :board identity :identity}]
-                (->> (boards/find-threads datomic (:db/id board) identity)
-                     (map #(assoc % :thread/writenum (comments/count-writenum datomic (:db/id %) identity)))
-                     (map #(update % :thread/watchers
-                        (fn [watchers] (apply hash-set watchers))
-
-                        ))
-                     ((fn [threads] (assoc board :board/threads (vec threads))))
-                     ((fn [board] (assoc board :user/permissions (:user/permissions identity))))))))
+                (let [threads (boards/find-threads datomic (:db/id board) identity)
+                      thread-ids (mapv :db/id threads)
+                      writenums (if (seq thread-ids)
+                                  (comments/count-writenums-batch datomic thread-ids identity)
+                                  {})]
+                  (-> board
+                      (assoc :board/threads
+                             (->> threads
+                                  (mapv #(assoc % :thread/writenum (get writenums (:db/id %) 0)))
+                                  (mapv #(update % :thread/watchers (fn [w] (apply hash-set w))))))
+                      (assoc :user/permissions (:user/permissions identity)))))))

--- a/src/clj/back_channeling/resource/thread.clj
+++ b/src/clj/back_channeling/resource/thread.clj
@@ -61,8 +61,9 @@
    :handle-created (fn [_]
                      {:status "ok"})
    :handle-ok (fn [_]
-                (threads/find-thread datomic thread-id))))
+                (threads/find-thread-meta datomic thread-id))))
 
+;; Readonly resource returns full thread with comments (used by bot, curation)
 (defn thread-readonly-resource [{:keys [datomic]} thread-id]
   (liberator/resource base-resource
    :allowed-methods [:get]

--- a/src/cljs/back_channeling/events.cljs
+++ b/src/cljs/back_channeling/events.cljs
@@ -176,17 +176,21 @@
      {:http {:path (str "/api/board/" name "/thread/" id "/comments/" range-str)
              :handler (fn [response] [callback-event {:thread thread :from from :comments response}])}})))
 
+(defn- merge-comments
+  "Merge new comments into existing collection efficiently."
+  [existing new-comments]
+  (->> (into (sorted-map)
+             (map (fn [c] [(:comment/no c) c]))
+             (concat existing new-comments))
+       vals))
+
 (rf/reg-event-fx
  ::comments-fetched-for-thread
  (fn [{:keys [db]} [_ {:keys [thread from comments]}]]
    (let [id (:db/id thread)]
      {:db (-> db
               (assoc-in [:threads id :db/id] id)
-              (update-in [:threads id :thread/comments]
-                         #(->> (concat % comments)
-                               (map (fn [c] [(:comment/no c) c]))
-                               (into (sorted-map))
-                               vals))
+              (update-in [:threads id :thread/comments] merge-comments comments)
               (update :page dissoc :loading?))
       :dispatch [::update-readnum id]})))
 
@@ -216,11 +220,7 @@
                            (max lastnum)))]
      (-> db
          (assoc-in [:threads id :db/id] id)
-         (update-in [:threads id :thread/comments]
-                    #(->> (concat % comments)
-                          (map (fn [c] [(:comment/no c) c]))
-                          (into (sorted-map))
-                          vals))
+         (update-in [:threads id :thread/comments] merge-comments comments)
          (cond->
            (and idx readnum)
            (assoc-in [:board :board/threads idx :thread/readnum] readnum))))))

--- a/test/clj/back_channeling/endpoint/api_test.clj
+++ b/test/clj/back_channeling/endpoint/api_test.clj
@@ -3,11 +3,11 @@
             [clojure.edn :as edn]
             [back-channeling.test-helper :as th]
             [back-channeling.resource.board :refer [boards-resource board-resource]]
-            [back-channeling.resource.thread :refer [threads-resource]]
+            [back-channeling.resource.thread :refer [threads-resource thread-resource
+                                                      thread-readonly-resource]]
             [back-channeling.resource.comment :refer [comments-resource]]
             [back-channeling.resource.reaction :refer [reactions-resource]]
-            [back-channeling.resource.article :refer [articles-resource]]
-            [liberator.dev :refer [wrap-trace]]))
+            [back-channeling.resource.article :refer [articles-resource]]))
 
 (def ^:dynamic *system* nil)
 
@@ -55,6 +55,41 @@
           response (handler request)]
       (is (= 201 (:status response))))))
 
+;; -- Board resource (single board with threads) ---------------------------
+
+(deftest board-resource-test
+  (let [_ (th/create-test-user *system* "alice" "alice@test.com")
+        _ (th/create-test-board *system* "myboard" "Test board")]
+    ;; Create a thread so board has content
+    (let [handler (threads-resource *system* "myboard")
+          request (th/make-authenticated-request :post
+                    :identity {:user/name "alice"}
+                    :body {:thread/title "Thread 1"
+                           :comment/content "Hello"})
+          response (handler request)]
+      (is (= 201 (:status response))))
+
+    (testing "GET board returns threads with writenum defaulting to 0"
+      (let [handler (board-resource *system* "myboard")
+            request (th/make-authenticated-request :get
+                      :identity {:user/name "alice"})
+            response (handler request)
+            body (parse-body response)]
+        (is (= 200 (:status response)))
+        (is (= 1 (count (:board/threads body))))
+        ;; alice posted 1 comment so writenum should be 1
+        (is (= 1 (:thread/writenum (first (:board/threads body)))))))
+
+    (testing "GET board with different user has writenum 0"
+      (th/create-test-user *system* "bob" "bob@test.com")
+      (let [handler (board-resource *system* "myboard")
+            request (th/make-authenticated-request :get
+                      :identity {:user/name "bob"})
+            response (handler request)
+            body (parse-body response)]
+        (is (= 200 (:status response)))
+        (is (= 0 (:thread/writenum (first (:board/threads body)))))))))
+
 ;; -- Thread tests ---------------------------------------------------------
 
 (deftest threads-resource-test
@@ -80,6 +115,41 @@
                                     :comment/content "Should fail"})}
             response (handler request)]
         (is (= 401 (:status response)))))))
+
+;; -- Thread resource (single thread metadata) -----------------------------
+
+(deftest thread-resource-test
+  (let [_ (th/create-test-user *system* "alice" "alice@test.com")
+        _ (th/create-test-board *system* "default" "Default board")
+        ;; Create a thread
+        create-handler (threads-resource *system* "default")
+        create-resp (create-handler
+                     (th/make-authenticated-request :post
+                       :identity {:user/name "alice"}
+                       :body {:thread/title "Meta test"
+                              :comment/content "First comment"}))
+        thread-id (:db/id (parse-body create-resp))]
+
+    (testing "GET thread returns metadata without comments"
+      (let [handler (thread-resource *system* "default" thread-id)
+            request (th/make-authenticated-request :get
+                      :identity {:user/name "alice"})
+            response (handler request)
+            body (parse-body response)]
+        (is (= 200 (:status response)))
+        (is (= "Meta test" (:thread/title body)))
+        (is (nil? (:thread/comments body)))))
+
+    (testing "GET readonly thread returns comments"
+      (let [handler (thread-readonly-resource *system* thread-id)
+            request (th/make-authenticated-request :get
+                      :identity {:user/name "alice"})
+            response (handler request)
+            body (parse-body response)]
+        (is (= 200 (:status response)))
+        (is (= "Meta test" (:thread/title body)))
+        (is (seq (:thread/comments body)))
+        (is (= "First comment" (:comment/content (first (:thread/comments body)))))))))
 
 ;; -- Article tests --------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 3 of the security/performance improvement plan — 6 performance fixes.

- **P4 [High]**: Add Datomic indexes on `:thread/comments` and `:read-comment/thread`
- **P1 [Critical]**: Replace N+1 `count-writenum` per-thread queries with single batch query
- **P6 [Medium]**: Limit fulltext search results to top 50
- **P2 [Critical]**: Remove unbounded comment pull from `find-thread` (metadata only)
- **P5 [Medium]**: Add scheduled eviction for expired token cache entries (5min interval)
- **P8 [Medium]**: Optimize frontend comment merge with shared `merge-comments` helper

## Test plan

- [x] `lein test` passes (15 tests, 54 assertions, 0 failures)
- [ ] Manual: board with many threads loads without N+1 (check REPL timing)
- [ ] Manual: fulltext search returns max 50 results
- [ ] Manual: thread detail view still loads comments via range API

🤖 Generated with [Claude Code](https://claude.com/claude-code)