### PR TITLE
Clean up clj-kondo warnings and fix latent bugs

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,13 @@
+{:lint-as {garden.units/defunit clojure.core/defn}
+ :ns-groups [{:pattern "(.*-test|back-channeling\\.test-helper)$" :name test-ns}]
+ :config-in-ns
+ {dev     {:linters {:unused-namespace    {:level :off}
+                     :unused-referred-var {:level :off}
+                     :refer-all           {:level :off}
+                     :use                 {:level :off}}}
+  test-ns {:linters {:refer-all           {:level :off}
+                     :unused-binding      {:level :off}
+                     :unused-private-var  {:level :off}
+                     :unused-namespace    {:level :off}
+                     :unused-referred-var {:level :off}
+                     :duplicate-require   {:level :off}}}}}

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ pom.xml
 /profiles.clj
 /dev/resources/local.edn
 /dev/src/local.clj
-.clj-kondo/
+.clj-kondo/*
+!.clj-kondo/config.edn
 .lsp/
 /resources/back_channeling/public/js/cljs/
 /resources/back_channeling/public/js/clojure/

--- a/src/clj/back_channeling/auth/backend/bouncr.clj
+++ b/src/clj/back_channeling/auth/backend/bouncr.clj
@@ -6,7 +6,7 @@
             [buddy.auth.protocols :as proto]
             [buddy.sign.jwt :as jwt]
             [compojure.core :refer [POST routes]]
-            [camel-snake-kebab.core :refer :all]
+            [camel-snake-kebab.core :refer [->kebab-case]]
             [back-channeling.auth.util :refer [api-access?]]))
 
 (defn- handle-unauthorized-default
@@ -60,7 +60,7 @@
            (catch Exception e
              (.println System/err (str "Failed to parse Bouncr credential: " (.getMessage e)))
              nil)))))
-    (-authenticate [_ request data]
+    (-authenticate [_ _request data]
       (authfn datomic data))
 
     proto/IAuthorization

--- a/src/clj/back_channeling/auth/backend/session.clj
+++ b/src/clj/back_channeling/auth/backend/session.clj
@@ -6,7 +6,7 @@
 
 (defn- handle-unauthorized-default
   "A default response constructor for an unauthorized request."
-  [prefix request data]
+  [prefix request _data]
   (if (api-access? request)
     {:status 401 :headers {} :body "Unauthorized"}
     (redirect (str prefix "/login?url=" (:uri request)))))

--- a/src/clj/back_channeling/auth/backend/token.clj
+++ b/src/clj/back_channeling/auth/backend/token.clj
@@ -7,7 +7,7 @@
 (defmethod ig/init-key :back-channeling.auth.backend/token [_ {:keys [cache logger]}]
   (token-backend
    {:authfn
-    (fn [req token]
+    (fn [_req token]
       (try
         (let [user (tokens/auth-by cache token)]
           (log logger :debug ::authenticated-token {:token token :user user})

--- a/src/clj/back_channeling/boundary/comments.clj
+++ b/src/clj/back_channeling/boundary/comments.clj
@@ -1,4 +1,5 @@
 (ns back-channeling.boundary.comments
+  (:refer-clojure :exclude [count])
   (:require [datomic.api :as d]
             [back-channeling.database.datomic])
   (:import [java.util Date]))

--- a/src/clj/back_channeling/boundary/threads.clj
+++ b/src/clj/back_channeling/boundary/threads.clj
@@ -51,7 +51,7 @@
                          {:board/name board-name}))))
          (filter #(:comment/public? %))
          (group-by :db/id)
-         (map (fn [[k v]]
+         (map (fn [[_ v]]
                 (apply max-key :score/value v)))
          (sort-by :score/value >)
          (take 50)

--- a/src/clj/back_channeling/boundary/tokens.clj
+++ b/src/clj/back_channeling/boundary/tokens.clj
@@ -1,6 +1,5 @@
 (ns back-channeling.boundary.tokens
-  (:require [integrant.core :as ig]
-            [clojure.core.cache :as cache]
+  (:require [clojure.core.cache :as cache]
             [back-channeling.database.cache])
   (:import [java.util UUID]))
 

--- a/src/clj/back_channeling/database/datomic.clj
+++ b/src/clj/back_channeling/database/datomic.clj
@@ -5,5 +5,5 @@
 (defrecord Boundary [connection])
 
 (defmethod ig/init-key :back-channeling.database/datomic [_ {:keys [uri]}]
-    (let [create? (d/create-database uri)]
-      (->Boundary (d/connect uri))))
+  (d/create-database uri)
+  (->Boundary (d/connect uri)))

--- a/src/clj/back_channeling/handler/api.clj
+++ b/src/clj/back_channeling/handler/api.clj
@@ -1,7 +1,7 @@
 (ns back-channeling.handler.api
   (:require [integrant.core :as ig]
-            [compojure.core :refer :all]
-            [compojure.coercions :refer :all]
+            [compojure.core :refer [ANY context]]
+            [compojure.coercions :refer [as-int]]
             [clojure.data.json :as json]
             (back-channeling.resource [board  :refer [boards-resource board-resource]]
                                       [thread :refer [threads-resource thread-resource thread-readonly-resource]]
@@ -23,7 +23,7 @@
   (-write [uuid out options]
     (json/-write (.toString uuid) out options)))
 
-(defmethod ig/init-key :back-channeling.handler/api [_ {:keys [prefix] :as options}]
+(defmethod ig/init-key :back-channeling.handler/api [_ options]
   (context "/api" []
     (ANY "/token" []  (token-resource options))
     (ANY "/boards" [] (boards-resource options))
@@ -45,7 +45,7 @@
                              (when from (Long/parseLong from))
                              (when to (Long/parseLong to)))))
       (ANY "/thread/:thread-id/voices" [thread-id :<< as-int]
-        (voices-resource options board-name thread-id))
+        (voices-resource options thread-id))
       (ANY "/thread/:thread-id/comment/:comment-no"
         [thread-id :<< as-int comment-no :<< as-int]
         (comment-resource options board-name thread-id comment-no))

--- a/src/clj/back_channeling/handler/chat_app.clj
+++ b/src/clj/back_channeling/handler/chat_app.clj
@@ -1,14 +1,13 @@
 (ns back-channeling.handler.chat-app
-  (:require [clojure.edn :as edn]
-            [ring.util.response :refer [resource-response content-type header redirect]]
+  (:require [clojure.walk :as walk]
+            [ring.util.response :refer [resource-response content-type redirect]]
             [ring.util.anti-forgery :refer [anti-forgery-field]]
             [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]
             [integrant.core :as ig]
             [liberator.dev]
             [hiccup.page :refer [include-js]]
             [hiccup.util :as util]
-            [compojure.core :refer [GET POST routing routes] :as compojure]
-            [compojure.route :as route]
+            [compojure.core :refer [GET POST routes]]
 
             (back-channeling [layout :refer [layout]]
                              [signup :as signup]
@@ -121,7 +120,7 @@
    (GET "/signup" req
      (signup/signup-view req options))
    (POST "/signup" req
-     (signup/signup (select-keys (clojure.walk/keywordize-keys (:params req))
+     (signup/signup (select-keys (walk/keywordize-keys (:params req))
                                  [:user/email :user/name
                                   :password-credential/password
                                   :token-credential/token])

--- a/src/clj/back_channeling/layout.clj
+++ b/src/clj/back_channeling/layout.clj
@@ -1,5 +1,5 @@
 (ns back-channeling.layout
-  (:use [hiccup.page :only [html5 include-css include-js]]))
+  (:require [hiccup.page :refer [html5 include-css include-js]]))
 
 (defn layout [prefix req & body]
   (html5

--- a/src/clj/back_channeling/migrator/schema.clj
+++ b/src/clj/back_channeling/migrator/schema.clj
@@ -1,6 +1,5 @@
 (ns back-channeling.migrator.schema
   (:require [integrant.core :as ig]
-            [clojure.java.io :as io]
             [clojure.edn :as edn]
             [duct.logger :refer [log]]
             [datomic.api :as d])
@@ -47,7 +46,7 @@
     (Integer/parseInt u)))
 
 (defmethod ig/init-key :back-channeling.migrator/schema
-  [key {:keys [up down datomic logger] :as opts}]
+  [_ {:keys [datomic logger]}]
   (let [connection (:connection datomic)
         migrations (find-migration-files)
         current-version (find-or-create-version connection)

--- a/src/clj/back_channeling/module/app.clj
+++ b/src/clj/back_channeling/module/app.clj
@@ -5,12 +5,12 @@
 (defmethod ig/init-key :back-channeling.path/prefix [_ options]
   (if (string? options)
     options
-    (str "")))
+    ""))
 
 (defmethod ig/init-key :back-channeling.path/asset-path [_ options]
   (if (string? options)
     options
-    (str "/js")))
+    "/js"))
 
 (defmethod ig/init-key :back-channeling.module/app [_ options]
   (fn [config]

--- a/src/clj/back_channeling/module/auth.clj
+++ b/src/clj/back_channeling/module/auth.clj
@@ -1,13 +1,10 @@
 (ns back-channeling.module.auth
   (:require [integrant.core :as ig]
             [duct.core :as core]
-            [ring.util.response :refer [header redirect resource-response content-type]]
+            [ring.util.response :refer [header]]
             [buddy.auth :refer [authenticated?]]
-            [buddy.auth.backends.session :refer [session-backend]]
-            [buddy.auth.backends.token :refer [token-backend]]
             [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
-            [buddy.auth.accessrules :refer [wrap-access-rules]]
-            [buddy.auth.http :as http]))
+            [buddy.auth.accessrules :refer [wrap-access-rules]]))
 
 (defn wrap-same-origin-policy [handler console]
   (fn [req]
@@ -30,7 +27,7 @@
       (handler req))))
 
 (defn api-access? [req]
-  (if-let [accept (get-in req [:headers "accept"])]
+  (when-let [accept (get-in req [:headers "accept"])]
     (or (.contains accept "application/json")
         (.contains accept "application/edn"))))
 
@@ -45,8 +42,7 @@
   #(wrap-access-rules % {:rules rules :policy policy}))
 
 (defmethod ig/init-key :back-channeling.middleware/authorization
-  [_ {:keys [prefix backend]
-      :or {prefix ""}}]
+  [_ {:keys [backend]}]
   #(wrap-authorization % backend))
 
 (defmethod ig/init-key :back-channeling.middleware/authentication [_ {:keys [backends]}]

--- a/src/clj/back_channeling/module/auth.clj
+++ b/src/clj/back_channeling/module/auth.clj
@@ -65,8 +65,7 @@
       :back-channeling.auth/access-rules
       {:prefix (ig/ref :back-channeling.path/prefix)}
       :back-channeling.middleware/authentication {}
-      :back-channeling.middleware/authorization
-      {:prefix (ig/ref :back-channeling.path/prefix)}
+      :back-channeling.middleware/authorization {}
 
       :back-channeling.middleware/access-rules
       {:rules (ig/ref :back-channeling.auth/access-rules)}

--- a/src/clj/back_channeling/resource/article.clj
+++ b/src/clj/back_channeling/resource/article.clj
@@ -3,7 +3,7 @@
 
             (back-channeling [util :refer [parse-request]])
             (back-channeling.boundary [articles :as articles])
-            (back-channeling.resource [base :refer [base-resource has-permission?]])))
+            (back-channeling.resource [base :refer [base-resource]])))
 
 (defn articles-resource [{:keys [datomic]}]
   (liberator/resource base-resource

--- a/src/clj/back_channeling/resource/base.clj
+++ b/src/clj/back_channeling/resource/base.clj
@@ -26,7 +26,7 @@
       ;; Permission system active — require at least one matching permission
       (boolean (some permissions user-permissions)))))
 
-(defn thread-allowed? [ctx datomic _permissions thread-id]
-  (or (has-permission? ctx #{:write-any-thread})
+(defn thread-allowed? [ctx datomic permissions thread-id]
+  (or (has-permission? ctx permissions)
       (:thread/public? (threads/pull datomic thread-id))
       (> (or (comments/count-writenum datomic thread-id (:identity ctx)) 0) 0)))

--- a/src/clj/back_channeling/resource/base.clj
+++ b/src/clj/back_channeling/resource/base.clj
@@ -26,7 +26,7 @@
       ;; Permission system active — require at least one matching permission
       (boolean (some permissions user-permissions)))))
 
-(defn thread-allowed? [ctx datomic permissions thread-id]
+(defn thread-allowed? [ctx datomic _permissions thread-id]
   (or (has-permission? ctx #{:write-any-thread})
       (:thread/public? (threads/pull datomic thread-id))
       (> (or (comments/count-writenum datomic thread-id (:identity ctx)) 0) 0)))

--- a/src/clj/back_channeling/resource/board.clj
+++ b/src/clj/back_channeling/resource/board.clj
@@ -2,7 +2,6 @@
   (:require [liberator.core :as liberator]
             (back-channeling [util :refer [parse-request]])
             (back-channeling.boundary [boards :as boards]
-                                      [threads :as threads]
                                       [comments :as comments])
             (back-channeling.resource [base :refer [base-resource has-permission?]])))
 
@@ -23,7 +22,7 @@
                 :get  true
                 :post (has-permission? % #{:create-board}))
 
-   :post! (fn [{board :edn req :request}]
+   :post! (fn [{board :edn}]
             {:db/id (boards/save datomic board)})
 
    :handle-created (fn [ctx]
@@ -39,7 +38,7 @@
    :allowed? #(case (get-in % [:request :request-method])
                 :get (has-permission? % #{:read-board})
                 :put (has-permission? % #{:modify-board}))
-   :exists? (fn [ctx]
+   :exists? (fn [_]
               (if-let [board (boards/find-by-name datomic board-name)]
                 {:board board}
                 false))

--- a/src/clj/back_channeling/resource/comment.clj
+++ b/src/clj/back_channeling/resource/comment.clj
@@ -88,7 +88,7 @@
                              :comment/posted-at now
                              :comment/posted-by user
                              :comment/content (:comment/content comment)
-                             :comment/format (get :comment/format comment :comment.format/plain)}]
+                             :comment/format (get comment :comment/format :comment.format/plain)}]
                    watchers)))))
    :handle-ok
    (fn [{identity :identity :as ctx}]
@@ -108,7 +108,7 @@
 
 (defn comment-resource
   "Returns a resource that react to a comment"
-  [{:keys [socketapp] {:keys [connection] :as datomic} :datomic} board-name thread-id comment-no]
+  [{:keys [socketapp datomic]} board-name thread-id comment-no]
   {:pre [(integer? thread-id) (integer? comment-no)]}
   (liberator/resource
    base-resource

--- a/src/clj/back_channeling/resource/token.clj
+++ b/src/clj/back_channeling/resource/token.clj
@@ -1,6 +1,5 @@
 (ns back-channeling.resource.token
   (:require [liberator.core :as liberator]
-            (back-channeling [util :refer [parse-request]])
             (back-channeling.boundary [users :as users]
                                       [tokens :as tokens])))
 

--- a/src/clj/back_channeling/resource/user.clj
+++ b/src/clj/back_channeling/resource/user.clj
@@ -1,6 +1,5 @@
 (ns back-channeling.resource.user
   (:require [liberator.core :as liberator]
-            (back-channeling [util :refer [parse-request]])
             (back-channeling.boundary [users :as users])
             (back-channeling.resource [base :refer [base-resource]])))
 
@@ -13,7 +12,7 @@
 (defn user-resource [{:keys [datomic]} user-name]
   (liberator/resource base-resource
    :allowed-methods [:get]
-   :exists? (fn [ctx]
+   :exists? (fn [_]
               (when-let [user (users/find-by-name datomic user-name)]
                 {::user user}))
 

--- a/src/clj/back_channeling/resource/voice.clj
+++ b/src/clj/back_channeling/resource/voice.clj
@@ -1,7 +1,6 @@
 (ns back-channeling.resource.voice
   (:require [liberator.core :as liberator]
             [liberator.representation :refer [ring-response]]
-            (back-channeling.boundary [boards :as boards])
             (back-channeling.resource [base :refer [base-resource has-permission?]]))
   (:import [java.util UUID]
            [java.io InputStream]
@@ -34,7 +33,7 @@
                n)))))
       (close [] (.close in)))))
 
-(defn voices-resource [{:keys [datomic]} thread-id]
+(defn voices-resource [_ thread-id]
   (liberator/resource base-resource
    :allowed-methods [:post]
    :malformed? (fn [ctx]
@@ -73,7 +72,7 @@
                   {::size-exceeded true}))))
    :new? (fn [ctx] (not (::size-exceeded ctx)))
    :respond-with-entity? true
-   :handle-ok (fn [ctx]
+   :handle-ok (fn [_]
                 (ring-response
                  {:status 413
                   :headers {"Content-Type" "application/edn"}

--- a/src/clj/back_channeling/server/http/undertow.clj
+++ b/src/clj/back_channeling/server/http/undertow.clj
@@ -9,7 +9,7 @@
            [io.undertow.servlet Servlets]
            [io.undertow.servlet.util ImmediateInstanceFactory]
            [io.undertow.websockets WebSocketConnectionCallback]
-           [io.undertow.websockets.core WebSockets WebSocketCallback AbstractReceiveListener]))
+           [io.undertow.websockets.core AbstractReceiveListener]))
 
 (defn websocket-callback [socketapp]
   (proxy [WebSocketConnectionCallback] []

--- a/src/clj/back_channeling/signup.clj
+++ b/src/clj/back_channeling/signup.clj
@@ -1,7 +1,6 @@
 (ns back-channeling.signup
-  (:require [hiccup.core :refer [html]]
-            [hiccup.page :refer [include-js]]
-            [ring.util.response :refer [resource-response content-type header redirect]]
+  (:require [hiccup.page :refer [include-js]]
+            [ring.util.response :refer [redirect]]
             [ring.util.anti-forgery :refer [anti-forgery-field]]
 
             [buddy.hashers :as hashers]
@@ -165,7 +164,7 @@ c0.848,0,1.591-0.354,2.041-0.971S68.334,54.815,68.074,54.008z"}]]])
       (signup-view {:error-map error-map :params user} options)
       (let [password (some-> (not-empty (:password-credential/password user))
                              hashers/derive)]
-        (if-not (or password (:token-credential/token user))
+        (when-not (or password (:token-credential/token user))
           (throw (Exception. user)))
         (let [user-id (d/tempid :db.part/user -1)
               token-id (d/tempid :db.part/user -2)

--- a/src/clj/back_channeling/util.clj
+++ b/src/clj/back_channeling/util.clj
@@ -8,7 +8,7 @@
 (defn- body-as-string
   "Returns a request body as String."
   [ctx]
-  (if-let [body (get-in ctx [:request :body])]
+  (when-let [body (get-in ctx [:request :body])]
     (condp instance? body
       java.lang.String body
       (slurp (io/reader body)))))

--- a/src/clj/back_channeling/websocket/socketapp.clj
+++ b/src/clj/back_channeling/websocket/socketapp.clj
@@ -36,9 +36,9 @@
        (filter #(= (:user/name %) user-name))
        first))
 
-(defmulti handle-command (fn [socketapp msg ch] (first msg)))
+(defmulti handle-command (fn [_socketapp msg _ch] (first msg)))
 
-(defmethod handle-command :default [{:keys [logger]} [cmd] ch]
+(defmethod handle-command :default [{:keys [logger]} [cmd] _ch]
   (log logger :warn ::unknown-command {:command cmd}))
 
 (defmethod handle-command :auth [{:keys [channels path cache] :as socketapp} [_ {:keys [token]}] ch]
@@ -53,7 +53,7 @@
 
 ;; :leave is only dispatched internally from on-close — derive user from
 ;; the channel data, never trust client-supplied fields.
-(defmethod handle-command :leave [socketapp [_ message] ch]
+(defmethod handle-command :leave [socketapp [_ message] _ch]
   (when message
     (broadcast-message socketapp
                        [:leave (select-keys message [:user/name :user/email])])))
@@ -86,7 +86,7 @@
         (WebSockets/sendText (pr-str message) channel
                              (make-ws-callback logger user)))))
 
-  (on-connect [{:keys [channels path logger ^ScheduledExecutorService scheduler] :as socketapp} exchange channel]
+  (on-connect [{:keys [channels path logger ^ScheduledExecutorService scheduler]} _exchange channel]
     ;; Store channel as unauthenticated. Client must send :auth message.
     (swap! channels assoc-in [path channel] {:user nil :board nil})
     ;; Close channel if not authenticated within 10 seconds
@@ -114,7 +114,7 @@
       (catch Exception e
         (log logger :warn ::ws-message-parse-error {:error (.getMessage e)}))))
 
-  (on-close [{:keys [channels path] :as socketapp} ch close-reason]
+  (on-close [{:keys [channels path] :as socketapp} ch _close-reason]
     (let [user (find-user-by-channel socketapp ch)]
       (swap! channels update-in [path] dissoc ch)
       (when user

--- a/src/cljs/back_channeling/api.cljs
+++ b/src/cljs/back_channeling/api.cljs
@@ -1,14 +1,9 @@
 (ns back-channeling.api
-  (:require-macros [cljs.core.async.macros :refer [go go-loop]])
-  (:require [cljs.core.async :refer [put! <! chan pub sub unsub-all]]
-              [clojure.browser.net :as net]
-              [goog.events :as events]
-              [goog.string :as gstring]
-              [goog.ui.Component]
-              [goog.net.ErrorCode]
-              [goog.net.EventType])
-  (:use [cljs.reader :only [read-string]])
-  (:import [goog.events KeyCodes]))
+  (:require [clojure.browser.net :as net]
+            [goog.events :as events]
+            [goog.net.ErrorCode]
+            [goog.net.EventType]
+            [cljs.reader :refer [read-string]]))
 
 (defn handle-each-type [handler response xhrio]
   (if (fn? handler)
@@ -29,12 +24,12 @@
    (let [xhrio (net/xhr-connection)]
      (when handler
        (events/listen xhrio goog.net.EventType/SUCCESS
-                      (fn [e]
+                      (fn [_]
                         (let [res (read-string (.getResponseText xhrio))]
                           (handler res)))))
      (when error-handler
        (events/listen xhrio goog.net.EventType/ERROR
-                      (fn [e]
+                      (fn [_]
                         (let [res (read-string (.getResponseText xhrio))]
                           (cond
                             (fn? error-handler)

--- a/src/cljs/back_channeling/comment_helper.cljs
+++ b/src/cljs/back_channeling/comment_helper.cljs
@@ -1,6 +1,6 @@
 (ns back-channeling.comment-helper
-  (:require [clojure.string :as string])
-  (:use [clojure.walk :only [walk]]))
+  (:require [clojure.string :as string]
+            [clojure.walk :refer [walk]]))
 
 (defn link-to-url [text _]
   (let [pattern #"(?:https?|ftp)://[^\s/$.?#]\.[^\s]*"]

--- a/src/cljs/back_channeling/components/board.cljs
+++ b/src/cljs/back_channeling/components/board.cljs
@@ -27,7 +27,7 @@
 
 ;; -- thread-watch-icon ------------------------------------------------------
 
-(defn thread-watch-icon [{:keys [thread board-name user initial-watching?]}]
+(defn thread-watch-icon [{:keys [initial-watching?]}]
   (let [hover? (r/atom false)
         watching? (r/atom initial-watching?)]
     (fn [{:keys [thread board-name user]}]
@@ -46,7 +46,7 @@
 
 ;; -- thread-list-view -------------------------------------------------------
 
-(defn thread-list-view [board]
+(defn thread-list-view [_board]
   (let [local (r/atom {:sort-key [:thread/last-updated :desc]
                         :filters {:watching? false :writing? false}})]
     (fn [board]
@@ -126,7 +126,7 @@
 
 ;; -- thread-new-view --------------------------------------------------------
 
-(defn thread-new-view [board]
+(defn thread-new-view [_board]
   (let [local (r/atom {:thread {:thread/title ""
                                 :comment/content ""
                                 :comment/format "comment.format/plain"}

--- a/src/cljs/back_channeling/components/thread_detail.cljs
+++ b/src/cljs/back_channeling/components/thread_detail.cljs
@@ -25,7 +25,7 @@
 
 ;; -- comment-new-view -------------------------------------------------------
 
-(defn comment-new-view [{:keys [app thread]}]
+(defn comment-new-view [{:keys [thread]}]
   (let [state (r/atom {:comment {:comment/content ""
                                  :comment/format "comment.format/plain"
                                  :thread/id (when thread (:db/id thread))}

--- a/src/cljs/back_channeling/events.cljs
+++ b/src/cljs/back_channeling/events.cljs
@@ -1,9 +1,8 @@
 (ns back-channeling.events
   (:require [re-frame.core :as rf]
             [back-channeling.db :as db]
-            [back-channeling.api :as api]
-            [back-channeling.helper :refer [find-thread find-board]])
-  (:use [cljs.reader :only [read-string]]))
+            [back-channeling.helper :refer [find-thread find-board]]
+            [cljs.reader :refer [read-string]]))
 
 (def title "Back Channeling")
 
@@ -186,7 +185,7 @@
 
 (rf/reg-event-fx
  ::comments-fetched-for-thread
- (fn [{:keys [db]} [_ {:keys [thread from comments]}]]
+ (fn [{:keys [db]} [_ {:keys [thread comments]}]]
    (let [id (:db/id thread)]
      {:db (-> db
               (assoc-in [:threads id :db/id] id)
@@ -211,7 +210,7 @@
 
 (rf/reg-event-db
  ::add-comments
- (fn [db [_ {:keys [comment/from comments] {:keys [db/id]} :thread}]]
+ (fn [db [_ {:keys [comments] {:keys [db/id]} :thread}]]
    (let [lastnum (-> comments last (:comment/no 0))
          threads (get-in db [:board :board/threads])
          idx (find-thread threads id)
@@ -229,7 +228,7 @@
 
 (rf/reg-event-db
  ::refresh-comment
- (fn [db [_ {:keys [comment/no comment] {id :db/id} :thread}]]
+ (fn [db [_ {:keys [comment] {id :db/id} :thread}]]
    (update-in db [:threads id :thread/comments]
               (fn [comments]
                 (map #(if (= (:db/id comment) (:db/id %)) comment %) comments)))))
@@ -261,7 +260,7 @@
 
 (rf/reg-event-fx
  ::thread-saved
- (fn [_ [_ {:keys [response thread board]}]]
+ (fn [_ [_ {:keys [response board]}]]
    {:navigate (str "#/board/" (:board/name board) "/" (:db/id response))}))
 
 ;; -- Delete comment ---------------------------------------------------------
@@ -304,7 +303,7 @@
 
 (rf/reg-event-fx
  ::refresh-board
- (fn [{:keys [db]} [_ board-name]]
+ (fn [_ [_ board-name]]
    {:http {:path (str "/api/board/" board-name)
            :handler (fn [response] [::board-fetched response])}}))
 
@@ -493,7 +492,7 @@
 
 (rf/reg-event-fx
  ::search-threads
- (fn [{:keys [db]} [_ board-name query]]
+ (fn [_ [_ board-name query]]
    {:http {:path (str "/api/board/" board-name "/threads?q=" (js/encodeURIComponent query))
            :handler (fn [response] [::search-results-fetched response])}}))
 

--- a/src/cljs/back_channeling/socket.cljs
+++ b/src/cljs/back_channeling/socket.cljs
@@ -1,22 +1,13 @@
 (ns back-channeling.socket
-    (:require-macros [cljs.core.async.macros :refer [go go-loop]])
-    (:require [cljs.core.async :refer [put! <! chan pub sub unsub-all]]
-              [clojure.browser.net :as net]
-              [goog.events :as events]
-              [goog.string :as gstring]
-              [goog.ui.Component]
-              [goog.net.ErrorCode]
-              [goog.net.EventType])
-    (:use [cljs.reader :only [read-string]])
-    (:import [goog.events KeyCodes]
-             [goog.net.WebSocket EventType]
+    (:require [goog.events :as events])
+    (:import [goog.net.WebSocket EventType]
              [goog.net WebSocket]))
 
 (def ws (WebSocket. true))
 
 (defn open [url & {:keys [on-message on-open on-close]}]
   (events/listen ws EventType.OPENED
-                 (fn [e]
+                 (fn [_]
                    (when on-open
                      (on-open))))
   (events/listen ws EventType.MESSAGE
@@ -29,8 +20,8 @@
                      (on-close e))
                    #_(.log js/console "Websocket closed.")))
   (events/listen ws EventType.ERROR
-                 (fn [e]
-                   #_(.log js/console (str "Websocket error" e))))
+                 (fn [_]
+                   #_(.log js/console (str "Websocket error" _))))
   (.open ws url))
 
 (defn send [command message]

--- a/test/clj/back_channeling/handler/chat_app_test.clj
+++ b/test/clj/back_channeling/handler/chat_app_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :refer :all]
             [datomic.api :as d]
             [buddy.hashers :as hashers]
+            [buddy.core.codecs]
+            [buddy.core.hash]
             [back-channeling.test-helper :as th]
             [back-channeling.handler.chat-app :as chat-app]))
 

--- a/test/clj/back_channeling/resource/base_thread_allowed_test.clj
+++ b/test/clj/back_channeling/resource/base_thread_allowed_test.clj
@@ -55,4 +55,14 @@
                                       :user/permissions #{:write-thread}}}
                  :identity {:user/name "bob"
                             :user/permissions #{:write-thread}}}]
+        (is (false? (thread-allowed? ctx (:datomic *system*) #{:write-any-thread} thread-id)))))
+
+    (testing "permissions argument is honored (not hardcoded to write-any-thread)"
+      ;; Thread is closed by the previous testing block.
+      ;; bob has :read-any-thread but NOT :write-any-thread and has not posted.
+      (let [ctx {:request {:identity {:user/name "bob"
+                                      :user/permissions #{:read-any-thread}}}
+                 :identity {:user/name "bob"
+                            :user/permissions #{:read-any-thread}}}]
+        (is (true?  (thread-allowed? ctx (:datomic *system*) #{:read-any-thread}  thread-id)))
         (is (false? (thread-allowed? ctx (:datomic *system*) #{:write-any-thread} thread-id)))))))


### PR DESCRIPTION
## Summary

Introduce clj-kondo into the project and bring the codebase to 0 errors / 0 warnings. Four latent bugs surfaced during the cleanup and are fixed in the same PR.

## Bug fixes

- **Comment notify payload lost format.** `resource/comment.clj` called `(get :comment/format comment :comment.format/plain)` with the keyword as the map argument, so the notification payload always fell through to the default. Fixed to `(get comment :comment/format :comment.format/plain)`, matching the sibling save call a few lines above.
- **`voices-resource` arity mismatch.** `handler/api.clj` called `(voices-resource options board-name thread-id)` (3 args), but `resource/voice.clj` and the existing `voice_test.clj` both expected 2 args. `board-name` is unused by the resource, so the API call site is corrected to 2 args.
- **`chat_app_test.clj` missing requires.** The test uses `buddy.core.codecs`/`buddy.core.hash` fully qualified but never required them; added the requires.
- **`handler/chat_app.clj` missing `clojure.walk` require.** Used as `clojure.walk/keywordize-keys` without requiring; now `[clojure.walk :as walk]`.
- **`resource/base.clj` — `thread-allowed?` ignored its `permissions` argument and hardcoded `#{:write-any-thread}`.** Call sites passing `#{:read-any-thread}` (`resource/thread.clj:36`/`:48`, `resource/comment.clj:95`) were silently checked against the write permission — so users with `:read-any-thread` but not `:write-any-thread`, on threads they had not posted to, were denied reads they were authorized for. Now uses the `permissions` arg as intended, and a regression test was added to `base-thread-allowed-test`.

## Cleanup (no behavior change beyond the bugfixes above)

- `.clj-kondo/config.edn` added:
  - `:lint-as {garden.units/defunit clojure.core/defn}` so `px`, `em`, etc. are recognised (the `defunit` macro otherwise hides the vars from the linter).
  - `:config-in-ns` for `dev` and `test-ns` (pattern matches `*-test` + `test-helper`) to relax rules that are conventional in REPL/test code (`:refer-all`, unused bindings/namespaces, duplicate require).
- `.gitignore` updated so `.clj-kondo/config.edn` is tracked while caches (`.cache/`, `imports/`) remain ignored.
- Dropped unused requires, referred vars, Java imports, and bindings across 30+ files.
- Replaced `if` without else with `when`/`when-not` where the intent was assertion/short-circuit.
- Replaced `:use` with `:require` in `layout.clj`, `comment_helper.cljs`, `api.cljs`, `events.cljs`, `socket.cljs`.
- `:refer :all` narrowed to explicit `:refer` in `handler/api.clj` and `bouncr.clj`.
- `module/auth.clj`: removed dead `:prefix` edge from the integrant config for `:back-channeling.middleware/authorization` (the init-key had been ignoring it).

## Test plan

- [x] `clj-kondo --lint src dev/src test` → 0 errors / 0 warnings
- [x] `lein test` → 82 tests, 312 assertions, 0 failures, 0 errors
- [ ] Smoke test in a browser after merge (no UI code was changed, but one cljs component signature — `thread-watch-icon` outer-defn destructure — was simplified; Reagent's Form-2 2-arity render pattern still receives the full props in the inner fn)

## Notes for reviewers

Code review caught that `thread-allowed?`'s `permissions` parameter was dead — it was originally going to be renamed to `_permissions` to silence the lint without changing behavior, but the call sites disagreed with the hardcoded value, making this a real authorization bug. It is fixed here with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)