### PR TITLE
Fix unclosed character class regex in comment-helper

### DIFF
--- a/src/cljs/back_channeling/comment_helper.cljs
+++ b/src/cljs/back_channeling/comment_helper.cljs
@@ -27,6 +27,10 @@
         (fn [x] (if (string? x) (f x options) x))
         html))
 
+;; Escapes metacharacters for splicing into a regex outside a character class.
+;; `-` and `/` are intentionally omitted: `-` is only special inside `[...]`,
+;; and `/` is only a regex-literal delimiter (irrelevant to `new RegExp(str)`).
+;; Callers must not splice the result inside `[...]`.
 (def ^:private re-special-chars #"([.*+?^${}()|\[\]\\])")
 
 (defn escape-regex [s]

--- a/src/cljs/back_channeling/comment_helper.cljs
+++ b/src/cljs/back_channeling/comment_helper.cljs
@@ -27,7 +27,7 @@
         (fn [x] (if (string? x) (f x options) x))
         html))
 
-(def ^:private re-special-chars #"([.*+?^${}()|\\[\]])")
+(def ^:private re-special-chars #"([.*+?^${}()|\[\]\\])")
 
 (defn escape-regex [s]
   (string/replace s re-special-chars "\\$1"))


### PR DESCRIPTION
## Summary

`comment-helper/escape-regex` used a malformed character class that broke ClojureScript compilation:

```
Compiling src/cljs/back_channeling/comment_helper.cljs ...
Execution error (PatternSyntaxException) ...
Unclosed character class near index 19
([.*+?^${}()|\\[\]])
                   ^
```

The original literal \`#\"([.*+?^${}()|\\\\[\\\\]])\"\` produces pattern string \`([.*+?^${}()|\\\\[\\\\]])\` — the engine sees an unclosed character class because \`\\]\` is not a valid terminator inside the class.

Changed to \`#\"([.*+?^${}()|\\[\\]\\\\])\"\` (escaped \`[\`, \`]\`, and literal backslash placed inside the class), which the engine reads as a well-formed class over regex metacharacters plus backslash.

## Verification

- \`lein run :duct/compiler\` (advanced optimizations) — 0 errors / 2 unrelated warnings
- JVM smoke of the same pattern via \`re-pattern\`:
  ```
  (string/replace \"a.b*c[d]\\\\e\" #\"([.*+?^${}()|\\[\\]\\\\])\" \"\\\\\\\\$1\")
  => \"a\\\\.b\\\\*c\\\\[d\\\\]\\\\\\\\e\"
  ```
- \`lein test\` — 82 tests / 312 assertions / 0 failures
- \`clj-kondo --lint\` on the file — 0 errors / 0 warnings

## Test plan

- [x] Compile cljs: \`lein run :duct/compiler\`
- [x] Unit tests unchanged: \`lein test\`
- [ ] Exercise search-highlight in the running UI to confirm escaping still behaves as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)